### PR TITLE
Fixed unused argument warnings and parameter named like member

### DIFF
--- a/CameraAnchorModeMenuButton.gd
+++ b/CameraAnchorModeMenuButton.gd
@@ -9,6 +9,6 @@ func manage_id(ID):
 	VDGlobal.visual_debugger.debugger_camera.anchor_mode = ID
 	self.text = self.get_popup().get_item_text(ID)
 
-func _process(delta):
+func _process(_delta):
 	if get_child(0).visible:
 		get_child(0).rect_position = Vector2(rect_global_position.x, rect_global_position.y + rect_size.y)

--- a/EnablePersistentFollowButton.gd
+++ b/EnablePersistentFollowButton.gd
@@ -2,6 +2,6 @@ extends CheckButton
 
 onready var jump_to_node_button = VDGlobal.visual_debugger.get_node("TabContainer/VisualSelect/SelectedNodeInfo/JumpToSelectedNodeButton") # For speed and convenience.
 
-func _process(delta):
+func _process(_delta):
 	if self.pressed:
 		jump_to_node_button._on_JumpToSelectedNodeButton_pressed()

--- a/IndicatorDrawSurface.gd
+++ b/IndicatorDrawSurface.gd
@@ -57,10 +57,10 @@ var scale_at_mouse_grab = Vector2(.0, .0) # To know, to which side to move the s
 var node_scale_ratio = 1.0 # To preserve the correct ratio of the node scale.
 var concurrent_scale_mask = Vector2(1.0, 1.0) # To always keep correct sign relationships for both axis.
 
-func _process(delta):
+func _process(_delta):
 	update()
 
-func _input(event):
+func _input(_event):
 	if !VDGlobal.visual_debugger.mouse_is_over_visual_debugger_gui:
 		absolute_mouse_position = VDGlobal.visual_debugger.scene_node_selector.absolute_mouse_position
 		var absolute_mouse_position_with_scale = absolute_mouse_position / VDGlobal.visual_debugger.scale # For speed and convenience.
@@ -167,7 +167,7 @@ func rotate_on_axis():
 			else:
 				node.set(transform_getsetters[1], node.get(transform_getsetters[1]) + (old_mouse_position.y - absolute_mouse_position.y) * ROTATION_COEFFICIENT)
 
-func draw_arrow_head(arrow_direction_vector, center_of_the_node, tip_of_the_arrow, line_color, arrow_length, thickness):
+func draw_arrow_head(arrow_direction_vector, tip_of_the_arrow, line_color, arrow_length, thickness):
 	draw_line(tip_of_the_arrow, tip_of_the_arrow + Vector2(arrow_direction_vector.y, -arrow_direction_vector.x) * arrow_length, line_color, thickness, true)
 	draw_line(tip_of_the_arrow, tip_of_the_arrow - Vector2(arrow_direction_vector.y, -arrow_direction_vector.x) * arrow_length, line_color, thickness, true)
 	draw_line(tip_of_the_arrow + arrow_direction_vector * arrow_length, tip_of_the_arrow + \
@@ -236,12 +236,12 @@ func draw_tips_and_axis_characters():
 
 	if VDGlobal.visual_debugger.transformation_mode == VDGlobal.visual_debugger.VD_Transformation_modes.MOVE || \
 	   VDGlobal.visual_debugger.transformation_mode == VDGlobal.visual_debugger.VD_Transformation_modes.ROTATE:
-		draw_arrow_head(arrow_direction_vector_x, center_of_the_node, x_arrow_tip_position, x_arrow_color, -7.5, 2.0)
-		draw_arrow_head(arrow_direction_vector_y, center_of_the_node, y_arrow_tip_position, y_arrow_color, 7.5, 2.0)
-		draw_arrow_head(arrow_direction_vector_x, center_of_the_node, x_arrow_tip_position, x_arrow_color, -5.0, 2.0)
-		draw_arrow_head(arrow_direction_vector_y, center_of_the_node, y_arrow_tip_position, y_arrow_color, 5.0, 2.0)
-		draw_arrow_head(arrow_direction_vector_x, center_of_the_node, x_arrow_tip_position, x_arrow_color, -2.5, 2.0)
-		draw_arrow_head(arrow_direction_vector_y, center_of_the_node, y_arrow_tip_position, y_arrow_color, 2.5, 2.0)
+		draw_arrow_head(arrow_direction_vector_x, x_arrow_tip_position, x_arrow_color, -7.5, 2.0)
+		draw_arrow_head(arrow_direction_vector_y, y_arrow_tip_position, y_arrow_color, 7.5, 2.0)
+		draw_arrow_head(arrow_direction_vector_x, x_arrow_tip_position, x_arrow_color, -5.0, 2.0)
+		draw_arrow_head(arrow_direction_vector_y, y_arrow_tip_position, y_arrow_color, 5.0, 2.0)
+		draw_arrow_head(arrow_direction_vector_x, x_arrow_tip_position, x_arrow_color, -2.5, 2.0)
+		draw_arrow_head(arrow_direction_vector_y, y_arrow_tip_position, y_arrow_color, 2.5, 2.0)
 	elif VDGlobal.visual_debugger.transformation_mode == VDGlobal.visual_debugger.VD_Transformation_modes.SCALE:
 		draw_rect(Rect2(x_arrow_tip_position - scale_tip_rectangle_size * .5, scale_tip_rectangle_size), x_arrow_color, true)
 		draw_rect(Rect2(y_arrow_tip_position - scale_tip_rectangle_size * .5, scale_tip_rectangle_size), y_arrow_color, true)

--- a/Outliner.gd
+++ b/Outliner.gd
@@ -123,7 +123,7 @@ func find_widest_and_deepest_branches(current_branch_root_item):
 		if current_branch_root_item == null:
 			break
 
-func _on_Outliner_item_collapsed(item):
+func _on_Outliner_item_collapsed(_item):
 	if !dont_find_the_widest_branch_while_building_the_tree:
 		absolute_widest_branch_width = 0
 		deepest_branch_width = 0
@@ -145,7 +145,7 @@ func find_if_mouse_is_over_outliner():
 	else:
 		return false
 
-func _process(delta):
+func _process(_delta):
 	if find_if_mouse_is_over_outliner():
 		if parent_node.get_child_count() > 1:
 			parent_node.remove_child(selection_overlay)

--- a/OutlinerHScrollBar.gd
+++ b/OutlinerHScrollBar.gd
@@ -15,7 +15,7 @@ func find_vertical_scroll_bar():
 		if outliner_children[i].get_class() == "VScrollBar":
 			return outliner_children[i]
 
-func _process(delta):
+func _process(_delta):
 	the_vertical_scroll_bar.rect_position.x = outliner_container.rect_size.x + RIGHT_OFFSET_FOR_V_SCROLL_BAR + value
 	if outliner.absolute_widest_branch_width > branch_width_threshold:
 		visible = true

--- a/RunButton.gd
+++ b/RunButton.gd
@@ -3,6 +3,6 @@ extends Button
 func _on_RunButton_button_down():
 	get_tree().paused = false
 
-func _process(delta):
+func _process(_delta):
 	if Input.is_key_pressed(KEY_CONTROL) && Input.is_key_pressed(KEY_F9):
 		get_tree().paused = false

--- a/SceneNodeSelector.gd
+++ b/SceneNodeSelector.gd
@@ -31,7 +31,7 @@ func manage_customization_params(event):
 		elif event.button_index == BUTTON_WHEEL_DOWN:
 			selection_radius = max(selection_radius - selection_radius * SELECTION_RADIUS_CHANGE_COEFFICIENT, MIN_SELECTION_RADIUS_SIZE)
 
-func _process(delta):
+func _process(_delta):
 	absolute_mouse_position = get_viewport().get_mouse_position()
 	relative_mouse_position = VDGlobal.visual_debugger.debugger_camera.position + absolute_mouse_position * VDGlobal.visual_debugger.debugger_camera.zoom
 	update()

--- a/StepButton.gd
+++ b/StepButton.gd
@@ -11,7 +11,7 @@ func do_a_step():
 
 var button_is_being_pressed = false # To manage single click.
 
-func _process(delta):
+func _process(_delta):
 	if Input.is_key_pressed(KEY_F9):
 		if !button_is_being_pressed:
 			button_is_being_pressed = true

--- a/TransformationModeButton.gd
+++ b/TransformationModeButton.gd
@@ -9,6 +9,6 @@ func manage_id(ID):
 	VDGlobal.visual_debugger.transformation_mode = ID
 	self.text = "Transformation mode: " + self.get_popup().get_item_text(ID)
 
-func _process(delta):
+func _process(_delta):
 	if get_child(0).visible:
 		get_child(0).rect_position = Vector2(rect_global_position.x, rect_global_position.y + rect_size.y)

--- a/VisualDebugger.gd
+++ b/VisualDebugger.gd
@@ -80,9 +80,9 @@ func manage_camera_movement(speed):
 	if direction.length() > VDGlobal.APPROXIMATION_FLOAT:
 		is_moving_to_node = false
 
-func set_moving_to_node(state, relative_position):
+func set_moving_to_node(state, new_relative_position):
 	is_moving_to_node = state
-	self.relative_position = relative_position
+	self.relative_position = new_relative_position
 
 func move_to_the_node(delta):
 	var movement_speed = delta * camera_move_lerp_speed # To save resources.

--- a/VisualDebuggerBackground.gd
+++ b/VisualDebuggerBackground.gd
@@ -2,7 +2,7 @@ extends Panel
 
 onready var visual_debugger = get_parent() # For speed and convenience.
 
-func _process(delta):
+func _process(_delta):
 	var mouse_viewport_position = get_viewport().get_mouse_position() # For speed and convenience.
 	if mouse_viewport_position.x < get_rect().size.x * VDGlobal.visual_debugger.scale.x && mouse_viewport_position.y < get_rect().size.y * VDGlobal.visual_debugger.scale.y:
 		if !visual_debugger.mouse_is_over_visual_debugger_gui:

--- a/WarningLine.gd
+++ b/WarningLine.gd
@@ -6,7 +6,7 @@ var time_left = .0 # To know, when to reset the time.
 const BLINK_TIME = 4.0 # For how long to blink.
 const BLINK_SPEED = 2.0 # How quickly to blink.
 
-func _on_WarningLine_text_changed(new_text):
+func _on_WarningLine_text_changed(_new_text):
 	blink_the_message = true
 	time_left = BLINK_TIME
 

--- a/WatchName.gd
+++ b/WatchName.gd
@@ -2,7 +2,7 @@ extends TextEdit
 
 var focus_was_outside = true # To only select all the first time.
 
-func _on_WatchName_gui_input(ev):
+func _on_WatchName_gui_input(_ev):
 	if Input.is_mouse_button_pressed(BUTTON_LEFT) && focus_was_outside:
 		focus_was_outside = false
 		select_all()

--- a/WatchesList.gd
+++ b/WatchesList.gd
@@ -308,7 +308,7 @@ func update_watches():
 		else:
 			select(item_count - 1)
 
-func _process(delta):
+func _process(_delta):
 	if !get_tree().paused || previous_h_scroll_value != h_scroll_value:
 		update_watches()
 

--- a/ZoomTo.gd
+++ b/ZoomTo.gd
@@ -5,7 +5,7 @@ func _on_ZoomTo_pressed():
 
 var zoom_to_is_being_pressed = false # To execute the zoom only once.
 
-func _process(delta):
+func _process(_delta):
 	if Input.is_key_pressed(KEY_F10):
 		if !zoom_to_is_being_pressed:
 			_on_ZoomTo_pressed()


### PR DESCRIPTION
Not all projects have unused-argument warning disabled, so I added underscores in front of all unused arguments. In addition, I removed `center_of_the_node` not used in `draw_arrow_head()`. If you intended to use it for something later, just tell me and suggest another change.