### PR TITLE
Fixed return value discarded warnings by adding disable comment

### DIFF
--- a/CameraAnchorModeMenuButton.gd
+++ b/CameraAnchorModeMenuButton.gd
@@ -1,6 +1,7 @@
 extends MenuButton
 
 func _ready():
+	#warning-ignore:return_value_discarded
 	self.get_popup().connect("id_pressed", self, "manage_id")
 	if VDGlobal.visual_debugger.debugger_camera:
 		self.text = str(VDGlobal.visual_debugger.debugger_camera.anchor_mode)

--- a/TransformationModeButton.gd
+++ b/TransformationModeButton.gd
@@ -3,6 +3,7 @@ extends MenuButton
 func _ready():
 	var parent_pos = get_parent().get_global_transform().origin # For speed and convenience.
 	self.get_parent().get_global_transform().origin = parent_pos
+	#warning-ignore:return_value_discarded
 	self.get_popup().connect("id_pressed", self, "manage_id")
 
 func manage_id(ID):


### PR DESCRIPTION
I decided to disable the warnings on a per-line basis so project owners don't have to disable it on the whole project. I think this is the least intrusive solution.

An alternative that doesn't need a new line is to write var _err = ...connect(...)

Another alternative is to actually check the Error result.