### PR TITLE
Fix "No loader found for resource ... .svg.import"

### DIFF
--- a/Outliner.gd
+++ b/Outliner.gd
@@ -28,7 +28,7 @@ func load_textures(var dir_path):
 	var file_name = dir.get_next()
 
 	while file_name != "":
-		if !dir.current_is_dir():
+		if !dir.current_is_dir() and file_name.ends_with(".svg"):
 			icon_dictionary[file_name.replace("icon_", "").replace(".svg", "").replace("_", "")] = load(dir_path + "/" + file_name)
 		file_name = dir.get_next()
 


### PR DESCRIPTION
Only load actual .svg, not their .import files

Repro:
In the editor, run game and open the Visual Debugger panel. You will see many errors like:

> E 0:00:00.315   _load: No loader found for resource: res://VisualDebugger/icons/icon_a_r_v_r_anchor.svg.import.
>   <C++ Error>   Method failed. Returning: RES()
>   <C++ Source>  core/io/resource_loader.cpp:285 @ _load()
>   <Stack Trace> Outliner.gd:32 @ load_textures()
> 				Outliner.gd:36 @ _ready()
> 				VDGlobal.gd:24 @ _ready()